### PR TITLE
Fix channel thumb display in claim list

### DIFF
--- a/ui/scss/component/_claim-list.scss
+++ b/ui/scss/component/_claim-list.scss
@@ -420,6 +420,13 @@
   }
 }
 
+.claim-preview__wrapper--channel{
+  .media__thumb {
+    background-size:contain;
+    background-color:transparent;
+  }
+}
+
 .claim-tile__title {
   margin: var(--spacing-s);
   font-weight: 600;


### PR DESCRIPTION
## PR Checklist

<!-- For the checkbox formatting to work properly, make sure there are no spaces on either side of the "x" -->

Please check all that apply to this PR using "x":

- [x] I have checked that this PR is not a duplicate of an existing PR (open, closed or merged)
- [x] I have checked that this PR does not introduce a breaking change
- [ ] This PR introduces breaking changes and I have provided a detailed explanation below

## PR Type

What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting)
- [ ] Refactoring (no functional changes)
- [ ] Documentation changes
- [x] Other - Please describe:

## Fixes

## What is the current behavior?
channel thumbs are square in 99.9% cases. new UI for listing claims assumes aspect ratio for content, not for channels.
## What is the new behavior?
channel thumb background image is set to contain and color to transparent.